### PR TITLE
VS Code settings and tasks for dev containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,13 +24,17 @@ RUN groupadd --gid $USER_GID $USERNAME \
 WORKDIR /workspace
 
 # Add the IBM Cloud CLI
-RUN wget -O bluemix-cli.tar.gz https://clis.cloud.ibm.com/download/bluemix-cli/1.4.0/linux64 && \
-    tar xzf bluemix-cli.tar.gz && \
-    cd Bluemix_CLI/ && \
-    ./install && \
-    cd .. && \
-    rm -fr Bluemix_CLI/ bluemix-cli.tar.gz && \
-    ibmcloud cf install
+RUN if [ $(uname -m) != aarch64 ]; then \
+        wget -O bluemix-cli.tar.gz https://clis.cloud.ibm.com/download/bluemix-cli/1.4.0/linux64 && \
+        tar xzf bluemix-cli.tar.gz && \
+        cd Bluemix_CLI/ && \
+        ./install && \
+        cd .. && \
+        rm -fr Bluemix_CLI/ bluemix-cli.tar.gz && \
+        ibmcloud cf install; \
+    else \
+        echo "aarch64 not supported"; \
+    fi;
 
 # Establish Python dependencies
 COPY requirements.txt .

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 		"donjayamanne.githistory",
     	"bbenoist.vagrant",
 		"cstrap.flask-snippets",
-    	"wholroyd.jinja"
+    	"wholroyd.jinja",
+		"github.vscode-pull-request-github"
 	],
 	"forwardPorts": [8080]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+.noseids
 coverage.xml
 *,cover
 .hypothesis/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-    "python.linting.pylintEnabled": true
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.testing.nosetestsEnabled": true,
+    "python.testing.nosetestArgs": ["-c=setup.cfg"],
+    "cucumberautocomplete.steps": ["features/steps/*.py"],
+    "cucumberautocomplete.syncfeatures": "features/*.feature",
+    "cucumberautocomplete.strictGherkinCompletion": true,
+    "cucumberautocomplete.strictGherkinValidation": true,
+    "cucumberautocomplete.smartSnippets": true,
+    "cucumberautocomplete.gherkinDefinitionPart": "@(given|when|then)\\(",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "TDD tests",
+            "type": "shell",
+            "command": "nosetests",
+            "problemMatcher": [],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,38 @@
 {
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
             "label": "TDD tests",
             "type": "shell",
             "command": "nosetests",
-            "problemMatcher": [],
-            "group": {
-                "kind": "test",
-                "isDefault": true
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated",
             }
-        }
+        },
+        {
+            "label": "BDD tests",
+            "type": "shell",
+            "command": "honcho start >/dev/null 2>&1 & sleep 5 && behave; kill %%",
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated",
+            }
+        },
+        {
+            "label": "TDD & BDD tests",
+            "type": "shell",
+            "group": "test",
+            "dependsOrder": "sequence",
+            "dependsOn": ["TDD tests", "BDD tests"],
+            "presentation": {
+                "reveal": "never",
+            }
+        },
     ]
+        
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,10 @@
 applications:
-- name: lab-flask-bdd-sc
+- name: lab-flask-bdd
   path: .
   instances: 2
   memory: 64M
   disk_quota: 1024M
-  host: lab-flask-bdd-sc
+  host: lab-flask-bdd
   domain: mybluemix.net
   #command: gunicorn --bind 0.0.0.0:$PORT --log-level=info app:app
   buildpack: python_buildpack

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,10 @@
 applications:
-- nme: lab-flask-bdd
+- name: lab-flask-bdd-sc
   path: .
   instances: 2
   memory: 64M
   disk_quota: 1024M
-  host: lab-flask-bdd
+  host: lab-flask-bdd-sc
   domain: mybluemix.net
   #command: gunicorn --bind 0.0.0.0:$PORT --log-level=info app:app
   buildpack: python_buildpack


### PR DESCRIPTION
This PR configures the settings and tasks in `.vscode` to enable several functionalities in VS Code dev containers for `lab-flask-bdd`, includeing
- Linting highlight by `pylint` using VS Code Python extension (https://code.visualstudio.com/docs/python/linting)
- Run TDD tests by `nose` using VS Code Python extension (https://code.visualstudio.com/docs/python/testing)
- Run both TDD & BDD tests using VS Code Tasks (selecting tasks in __Run Test Task__ from the **Command Palette**)